### PR TITLE
Remove PGB members listing

### DIFF
--- a/template/content/governance.md
+++ b/template/content/governance.md
@@ -4,7 +4,7 @@ type: governance
 layout: governance
 ---
 
-Governance for the Open Cybersecurity Alliance is managed by its [Project Governing Board](#pgb) and its [Technical Steering Committee](#tsc). These two groups ensure that all OCA
+Governance for the Open Cybersecurity Alliance is by its [Project Governing Board](#pgb) and its [Technical Steering Committee](#tsc). These two groups ensure that all OCA
 stakeholders have a voice in decisions affecting the work and that the
 contributions of developers, corporate supporters, and technology
 consumers are all valued.

--- a/template/layouts/partials/tsc.html
+++ b/template/layouts/partials/tsc.html
@@ -2,13 +2,5 @@
 <p>The TSC directs the day-to-day technical activities of the OCA. TSC
 members include representatives from the developer community who are
 actively contributing to the project.</p>
-<h3>Current TSC Members</h3>
-{{ range where site.RegularPages "Section" "tsc-reps" }}
-{{ if .Params.tsc_rep_name }}
-    <div class="pgb-list">
-    <h4>{{ .Params.tsc_rep_name }}</h4>
-    <p>{{ .Params.tsc_rep_title }}<br>
-        {{ .Params.company }}</p>
-    </div>
-{{ end }}  
-{{ end }}
+
+<p>The list of current TSC members can be found <a href="https://github.com/opencybersecurityalliance/oca-admin/blob/master/TECHNICAL-STEERING-COMMITTEE.md">here</a>.</p>


### PR DESCRIPTION
This removes the listing of PGB members and adds a link to the GitHub PGB file instead. GItHub file is easier to manage when members change.